### PR TITLE
Fix App Store link

### DIFF
--- a/src/components/FinalCTASection.tsx
+++ b/src/components/FinalCTASection.tsx
@@ -25,7 +25,7 @@ export const FinalCTASection: React.FC = () => {
           <Button
             variant="secondary"
             size="lg"
-            href="https://apps.apple.com/us/app/thinkers-your-ai-team/id6743700517"
+            href="https://apps.apple.com/app/6743700517"
             className="text-lg px-12 py-4"
           >
             Download Thinkers

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -34,7 +34,7 @@ export const HeroSection: React.FC = () => {
             <Button
               variant="secondary"
               size="lg"
-              href="https://apps.apple.com/us/app/thinkers-your-ai-team/id6743700517"
+              href="https://apps.apple.com/app/6743700517"
               className="w-full sm:w-auto text-lg px-8 py-4"
             >
               Download on App Store

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -19,7 +19,7 @@ export const PricingSection: React.FC = () => {
         'Community support',
       ],
       ctaText: 'Start with Starter',
-      href: 'https://apps.apple.com/us/app/thinkers-your-ai-team/id6743700517',
+      href: 'https://apps.apple.com/app/6743700517',
     },
     {
       plan: 'Active',
@@ -36,7 +36,7 @@ export const PricingSection: React.FC = () => {
         'Early access to new features',
       ],
       ctaText: 'Choose Active',
-      href: 'https://apps.apple.com/us/app/thinkers-your-ai-team/id6743700517',
+      href: 'https://apps.apple.com/app/6743700517',
     },
     {
       plan: 'Power',
@@ -54,7 +54,7 @@ export const PricingSection: React.FC = () => {
         'White-label options',
       ],
       ctaText: 'Go Power',
-      href: 'https://apps.apple.com/us/app/thinkers-your-ai-team/id6743700517',
+      href: 'https://apps.apple.com/app/6743700517',
     },
   ]
 


### PR DESCRIPTION
## Summary
- update the App Store URL to https://apps.apple.com/app/6743700517

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6840d93041308324874674190ad6173f