### PR TITLE
Remove Learn More button

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -39,14 +39,6 @@ export const HeroSection: React.FC = () => {
             >
               Download on App Store
             </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              href="#features"
-              className="w-full sm:w-auto text-lg px-8 py-4 bg-white/10 text-white border-white/30 hover:bg-white/20 hover:border-white/50"
-            >
-              Learn More
-            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove unused "Learn More" call-to-action from HeroSection

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd3283f08324af4e0faa3c42be72